### PR TITLE
Add buffered REST sink to jvm brokers

### DIFF
--- a/streampipes-sinks-brokers-jvm/src/main/java/org/streampipes/sinks/brokers/jvm/BrokersJvmInit.java
+++ b/streampipes-sinks-brokers-jvm/src/main/java/org/streampipes/sinks/brokers/jvm/BrokersJvmInit.java
@@ -24,6 +24,7 @@ import org.streampipes.dataformat.json.JsonDataFormatFactory;
 import org.streampipes.dataformat.smile.SmileDataFormatFactory;
 import org.streampipes.messaging.jms.SpJmsProtocolFactory;
 import org.streampipes.messaging.kafka.SpKafkaProtocolFactory;
+import org.streampipes.sinks.brokers.jvm.bufferrest.BufferRestController;
 import org.streampipes.sinks.brokers.jvm.config.BrokersJvmConfig;
 import org.streampipes.sinks.brokers.jvm.jms.JmsController;
 import org.streampipes.sinks.brokers.jvm.kafka.KafkaController;
@@ -39,6 +40,7 @@ public class BrokersJvmInit extends StandaloneModelSubmitter {
             .add(new KafkaController())
             .add(new JmsController())
             .add(new RestController())
+            .add(new BufferRestController())
             .add(new RabbitMqController())
             .add(new PulsarController());
 

--- a/streampipes-sinks-brokers-jvm/src/main/java/org/streampipes/sinks/brokers/jvm/bufferrest/BufferRest.java
+++ b/streampipes-sinks-brokers-jvm/src/main/java/org/streampipes/sinks/brokers/jvm/bufferrest/BufferRest.java
@@ -1,0 +1,66 @@
+
+package org.streampipes.sinks.brokers.jvm.bufferrest;
+
+import org.apache.commons.io.Charsets;
+import org.apache.http.client.fluent.Request;
+import org.apache.http.entity.StringEntity;
+import org.slf4j.Logger;
+import org.streampipes.commons.exceptions.SpRuntimeException;
+import org.streampipes.dataformat.SpDataFormatDefinition;
+import org.streampipes.dataformat.json.JsonDataFormatDefinition;
+import org.streampipes.model.runtime.Event;
+import org.streampipes.sinks.brokers.jvm.bufferrest.buffer.BufferListener;
+import org.streampipes.sinks.brokers.jvm.bufferrest.buffer.MessageBuffer;
+import org.streampipes.wrapper.context.EventSinkRuntimeContext;
+import org.streampipes.wrapper.runtime.EventSink;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+
+public class BufferRest implements EventSink<BufferRestParameters>, BufferListener {
+
+  private static Logger LOG;
+  private List<String> fieldsToSend;
+  private SpDataFormatDefinition dataFormatDefinition;
+  private String restEndpointURI;
+  private MessageBuffer buffer;
+
+  public BufferRest() {
+    this.dataFormatDefinition = new JsonDataFormatDefinition();
+  }
+
+  @Override
+  public void onInvocation(BufferRestParameters parameters, EventSinkRuntimeContext runtimeContext) {
+    this.fieldsToSend = parameters.getFieldsToSend();
+    this.restEndpointURI = parameters.getRestEndpointURI();
+    this.buffer = new MessageBuffer(parameters.getBufferSize());
+    this.buffer.addListener(this);
+  }
+
+  @Override
+  public void onEvent(Event event) {
+    Map<String, Object> outEventMap = event.getSubset(fieldsToSend).getRaw();
+    try {
+      String json = new String(dataFormatDefinition.fromMap(outEventMap));
+      this.buffer.addMessage(json);
+    } catch (SpRuntimeException e) {
+      LOG.error("Could not parse incoming event");
+    }
+  }
+
+  @Override
+  public void onDetach() {
+    buffer.removeListener(this);
+  }
+
+  @Override
+  public void bufferFull(String messagesJsonArray) {
+    try {
+      Request.Post(restEndpointURI).body(new StringEntity(messagesJsonArray, Charsets.UTF_8)).execute();
+    } catch (IOException e) {
+      LOG.error("Could not reach endpoint at {}", restEndpointURI);
+    }
+  }
+}

--- a/streampipes-sinks-brokers-jvm/src/main/java/org/streampipes/sinks/brokers/jvm/bufferrest/BufferRestController.java
+++ b/streampipes-sinks-brokers-jvm/src/main/java/org/streampipes/sinks/brokers/jvm/bufferrest/BufferRestController.java
@@ -1,0 +1,53 @@
+package org.streampipes.sinks.brokers.jvm.bufferrest;
+
+import org.streampipes.model.DataSinkType;
+import org.streampipes.model.graph.DataSinkDescription;
+import org.streampipes.model.graph.DataSinkInvocation;
+import org.streampipes.model.schema.PropertyScope;
+import org.streampipes.sdk.builder.DataSinkBuilder;
+import org.streampipes.sdk.builder.StreamRequirementsBuilder;
+import org.streampipes.sdk.extractor.DataSinkParameterExtractor;
+import org.streampipes.sdk.helpers.*;
+import org.streampipes.wrapper.standalone.ConfiguredEventSink;
+import org.streampipes.wrapper.standalone.declarer.StandaloneEventSinkDeclarer;
+
+import java.util.List;
+
+public class BufferRestController extends StandaloneEventSinkDeclarer<BufferRestParameters> {
+
+	private static final String KEY = "bufferrest";
+	private static final String URI = ".uri";
+	private static final String COUNT = ".count";
+	private static final String FIELDS = ".fields-to-send";
+
+	@Override
+	public DataSinkDescription declareModel() {
+		return DataSinkBuilder.create("org.streampipes.sinks.brokers.jvm.bufferrest")
+						.category(DataSinkType.NOTIFICATION)
+						.withLocales(Locales.EN)
+						.requiredStream(StreamRequirementsBuilder
+								.create()
+								.requiredPropertyWithNaryMapping(EpRequirements.anyProperty(), Labels.withId(
+										KEY + FIELDS), PropertyScope.NONE)
+								.build())
+						.supportedFormats(SupportedFormats.jsonFormat())
+						.supportedProtocols(SupportedProtocols.kafka())
+ 						.requiredTextParameter(Labels.from(KEY + URI, "REST Endpoint URI", "REST Endpoint URI"))
+						.requiredIntegerParameter(Labels.from(KEY + COUNT, "Buffered Event Count",
+								"Number (1 <= x <= 1000000) of incoming events before sending data on to the given REST endpoint"),
+								1, 1000000, 1)
+						.build();
+	}
+
+	@Override
+	public ConfiguredEventSink<BufferRestParameters> onInvocation(DataSinkInvocation graph, DataSinkParameterExtractor extractor) {
+
+		List<String> fieldsToSend = extractor.mappingPropertyValues(KEY + FIELDS);
+		String restEndpointURI = extractor.singleValueParameter(KEY + URI, String.class);
+		int bufferSize = Integer.parseInt(extractor.singleValueParameter(KEY + COUNT, String.class));
+
+		BufferRestParameters params = new BufferRestParameters(graph, fieldsToSend, restEndpointURI, bufferSize);
+
+		return new ConfiguredEventSink<>(params, BufferRest::new);
+	}
+}

--- a/streampipes-sinks-brokers-jvm/src/main/java/org/streampipes/sinks/brokers/jvm/bufferrest/BufferRestParameters.java
+++ b/streampipes-sinks-brokers-jvm/src/main/java/org/streampipes/sinks/brokers/jvm/bufferrest/BufferRestParameters.java
@@ -1,0 +1,32 @@
+package org.streampipes.sinks.brokers.jvm.bufferrest;
+
+import org.streampipes.model.graph.DataSinkInvocation;
+import org.streampipes.wrapper.params.binding.EventSinkBindingParams;
+
+import java.util.List;
+
+public class BufferRestParameters extends EventSinkBindingParams {
+
+  private String restEndpointURI;
+  private List<String> fieldsToSend;
+  private int bufferSize;
+
+  public BufferRestParameters(DataSinkInvocation graph, List<String> fieldsToSend, String restEndpointURI, int bufferSize) {
+    super(graph);
+    this.fieldsToSend = fieldsToSend;
+    this.restEndpointURI = restEndpointURI;
+    this.bufferSize = bufferSize;
+  }
+
+  public List<String> getFieldsToSend() {
+    return fieldsToSend;
+  }
+
+  public String getRestEndpointURI() {
+    return restEndpointURI;
+  }
+
+  public int getBufferSize() {
+    return bufferSize;
+  }
+}

--- a/streampipes-sinks-brokers-jvm/src/main/java/org/streampipes/sinks/brokers/jvm/bufferrest/buffer/BufferListener.java
+++ b/streampipes-sinks-brokers-jvm/src/main/java/org/streampipes/sinks/brokers/jvm/bufferrest/buffer/BufferListener.java
@@ -1,0 +1,5 @@
+package org.streampipes.sinks.brokers.jvm.bufferrest.buffer;
+
+public interface BufferListener {
+    void bufferFull(String messagesJsonArray);
+}

--- a/streampipes-sinks-brokers-jvm/src/main/java/org/streampipes/sinks/brokers/jvm/bufferrest/buffer/MessageBuffer.java
+++ b/streampipes-sinks-brokers-jvm/src/main/java/org/streampipes/sinks/brokers/jvm/bufferrest/buffer/MessageBuffer.java
@@ -1,0 +1,62 @@
+package org.streampipes.sinks.brokers.jvm.bufferrest.buffer;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class MessageBuffer {
+    private int bufferSize;
+    private List<BufferListener> listeners;
+    private List<String> messages;
+
+    public MessageBuffer(int bufferSize) {
+        this.bufferSize = bufferSize;
+        this.messages = new ArrayList<String>();
+        this.listeners = new ArrayList<BufferListener>();
+    }
+
+    public void addMessage(String message) {
+        messages.add(message);
+
+        if (bufferSize <= messages.size()) {
+            notifyListeners();
+            clearBuffer();
+        }
+    }
+
+    private void clearBuffer() {
+        this.messages = new ArrayList<String>();
+    }
+
+    public void addListener(BufferListener listener){
+        listeners.add(listener);
+    }
+
+    public void removeListener(BufferListener listener){
+        listeners.remove(listener);
+    }
+
+    private String getMessagesAsJsonString() {
+        String messagesAsJson;
+        if (bufferSize > 1) {
+            messagesAsJson = "[";
+            int i = 1;
+            for (String message : messages) {
+                messagesAsJson += message;
+                if (i < messages.size()) {
+                    messagesAsJson += ",";
+                }
+                i++;
+            }
+            messagesAsJson += "]";
+        } else {
+            messagesAsJson = messages.get(0);
+        }
+        return messagesAsJson;
+    }
+    private void notifyListeners(){
+        String messagesJsonArray = getMessagesAsJsonString();
+        for(BufferListener listener : listeners) {
+            listener.bufferFull(messagesJsonArray);
+        }
+    }
+}

--- a/streampipes-sinks-brokers-jvm/src/main/resources/org.streampipes.sinks.brokers.jvm.bufferrest/documentation.md
+++ b/streampipes-sinks-brokers-jvm/src/main/resources/org.streampipes.sinks.brokers.jvm.bufferrest/documentation.md
@@ -1,0 +1,52 @@
+<!--
+
+  Copyright 2018 FZI Forschungszentrum Informatik
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+-->
+
+## Buffered REST Publisher
+
+<p align="center"> 
+    <img src="icon.png" width="150px;" class="pe-image-documentation"/>
+</p>
+
+***
+
+## Description
+
+Collects a given amount of events into a JSON array. Once this event count is reached
+the JSON array is posted to the given REST interface.
+
+***
+
+## Required input
+
+This sink does not have any requirements and works with any incoming event type.
+
+***
+
+## Configuration
+
+### REST URL
+
+The complete URL of the REST endpoint.
+
+### Buffer Size
+
+The amount of events before sending.
+
+## Output
+
+(not applicable for data sinks)

--- a/streampipes-sinks-brokers-jvm/src/main/resources/org.streampipes.sinks.brokers.jvm.bufferrest/strings.en
+++ b/streampipes-sinks-brokers-jvm/src/main/resources/org.streampipes.sinks.brokers.jvm.bufferrest/strings.en
@@ -1,0 +1,8 @@
+org.streampipes.sinks.brokers.jvm.bufferrest.title=Buffered REST Publisher
+org.streampipes.sinks.brokers.jvm.bufferrest.description=Collects a given amount of events into a JSON array. Once this event count is reached the JSON array is posted to the given REST interface.
+
+bufferrest.uri.title=REST URL
+bufferrest.uri.description=URL of the REST endoint
+
+bufferrest.count.title=Buffer Size
+bufferrest.count=The amount of events to buffer before sending them on


### PR DESCRIPTION
This will add a modified version of the original REST Publisher PE. This version will keep JSON events in a buffer of a given size. Once the amount of events is reached they are sent on in form of a JSON array